### PR TITLE
[FIX/#26] 피드 페이지 홈 페이지로 변경

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,8 @@ function App() {
 
   useEffect(() => {
     const path = location.pathname.split('/');
-    setPage(path[1]);
+    if (path[1]) setPage(path[1]);
+    else setPage('home');
   }, [location]);
 
   return (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -23,7 +23,7 @@ export default function Header({ page }) {
   return (
     <header className={styles.container}>
       <IoChevronBackOutline
-        className={styles.back}
+        className={`${styles.back} ${page === 'home' && styles.noEffect}`}
         onClick={() => navigate(-1)}
       />
       <h1 className={styles.title}>{handleTranslate(page)}</h1>

--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -18,6 +18,11 @@
     cursor: pointer;
   }
 
+  .noEffect {
+    color: white;
+    pointer-events: none;
+  }
+
   .setting {
     margin-right: 1rem;
     font-size: 1.25rem;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styles from './Navbar.module.scss';
 import { IoSearchOutline } from 'react-icons/io5';
-import { CgDisplayFullwidth } from 'react-icons/cg';
+import { HiHome } from 'react-icons/hi';
 import { ImBooks } from 'react-icons/im';
+// feed icon : import { CgDisplayFullwidth } from 'react-icons/cg';
 
 export default function Navbar({ page }) {
   return (
@@ -14,11 +15,8 @@ export default function Navbar({ page }) {
       >
         <IoSearchOutline />
       </Link>
-      <Link
-        to="/feed"
-        className={page === 'feed' ? styles.active : styles.link}
-      >
-        <CgDisplayFullwidth />
+      <Link to="/" className={page === 'home' ? styles.active : styles.link}>
+        <HiHome />
       </Link>
       <Link
         to="/mybooks"

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Search from './pages/Search';
 import NotFound from './pages/NotFound';
 import MyBooks from './pages/MyBooks';
-import Feed from './pages/Feed';
+import Home from './pages/Home';
 
 const router = createBrowserRouter([
   {
@@ -16,16 +16,16 @@ const router = createBrowserRouter([
     errorElement: <NotFound />,
     children: [
       {
+        index: true,
+        element: <Home />,
+      },
+      {
         path: 'search',
         element: <Search />,
       },
       {
         path: 'mybooks',
         element: <MyBooks />,
-      },
-      {
-        path: 'feed',
-        element: <Feed />,
       },
     ],
   },

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export default function Feed() {
+export default function Home() {
   return <div>See You At Ver.2!!!</div>;
 }


### PR DESCRIPTION
## 개요
피드 페이지를 홈으로 변경

## 작업 내용
- 피드 페이지였던 부분을 Home으로 변경
- React Router에서 index: true 설정
- 내비게이션 바 아이콘 변경
- 홈 페이지에서 뒤로 가기 버튼 비활성화

## 이슈 링크
main: #26 
related to: #1 